### PR TITLE
Updates for Cycle 27

### DIFF
--- a/docker/oods/Dockerfile
+++ b/docker/oods/Dockerfile
@@ -41,27 +41,6 @@ WORKDIR /home/saluser
 
 COPY --chown=saluser:saluser setup.sh /home/saluser
 
-# BEGIN fix for DM-35518 - remove this on the next cycle upgrade
-ARG ASTRO_METADATA_TRANSLATOR_COMMIT_SHA
-RUN source /opt/lsst/software/stack/loadLSST.bash && \
-    cd /home/saluser && \
-    git clone https://github.com/lsst/astro_metadata_translator && \
-    cd astro_metadata_translator && \
-    git checkout ${ASTRO_METADATA_TRANSLATOR_COMMIT_SHA} && \
-    setup -r /home/saluser/astro_metadata_translator && \
-    scons
-
-ARG OBS_LSST_COMMIT_SHA
-RUN source /opt/lsst/software/stack/loadLSST.bash && \
-    cd /home/saluser && \
-    git clone https://github.com/lsst/obs_lsst && \
-    cd obs_lsst && \
-    git checkout ${OBS_LSST_COMMIT_SHA} && \
-    setup -r /home/saluser/obs_lsst && \
-    setup -r /home/saluser/astro_metadata_translator && \
-    scons
-# END fix for DM-35518 - remove this on the next cycle upgrade
-
 ARG TS_DDSCONFIG_PACKAGE
 RUN git clone --depth 1 --branch ${TS_DDSCONFIG_PACKAGE} http://github.com/lsst-ts/ts_ddsconfig
 

--- a/docker/oods/setup.sh
+++ b/docker/oods/setup.sh
@@ -7,5 +7,3 @@ export OSPL_HOME=/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux
 source $OSPL_HOME/release.com
 source /opt/lsst/software/stack/loadLSST.bash
 setup -r /opt/lsst/ctrl_oods
-setup -r /home/saluser/obs_lsst
-setup -r /home/saluser/astro_metadata_translator

--- a/docker/test_oods/Dockerfile
+++ b/docker/test_oods/Dockerfile
@@ -1,5 +1,4 @@
 ARG CYCLE_TAG
-#FROM ts-dockerhub.lsst.org/develop-env:${CYCLE_TAG}
 FROM ts-dockerhub.lsst.org/deploy-sqre:${CYCLE_TAG}
 
 ARG LSST_STACK_VERSION

--- a/docker/test_oods/Dockerfile
+++ b/docker/test_oods/Dockerfile
@@ -1,5 +1,6 @@
 ARG CYCLE_TAG
-FROM ts-dockerhub.lsst.org/develop-env:${CYCLE_TAG}.000
+#FROM ts-dockerhub.lsst.org/develop-env:${CYCLE_TAG}
+FROM ts-dockerhub.lsst.org/deploy-sqre:${CYCLE_TAG}
 
 ARG LSST_STACK_VERSION
 ARG CTRL_OODS_GIT

--- a/docker/versions.sh
+++ b/docker/versions.sh
@@ -18,8 +18,8 @@ export PIKA_VERSION=1.1.0
 export REDIS_VERSION=3.5.3
 
 # set all the git tags or tickets for the versions you want to use for the containers
-export CTRL_OODS_GIT=tags/7.3.1
-export DM_IIP_DEPLOY_GIT=tags/7.4.1
+export CTRL_OODS_GIT=tags/7.3.2
+export DM_IIP_DEPLOY_GIT=tags/7.4.2
 #
 # remove the "tags/" or "tickets/"; these new values will be used to label containers
 #

--- a/docker/versions.sh
+++ b/docker/versions.sh
@@ -19,7 +19,7 @@ export REDIS_VERSION=3.5.3
 
 # set all the git tags or tickets for the versions you want to use for the containers
 export CTRL_OODS_GIT=tags/7.3.2
-export DM_IIP_DEPLOY_GIT=tags/7.4.2
+export DM_IIP_DEPLOY_GIT=tags/7.4.3
 #
 # remove the "tags/" or "tickets/"; these new values will be used to label containers
 #

--- a/docker/versions.sh
+++ b/docker/versions.sh
@@ -2,7 +2,7 @@
 #
 
 # t&s base container version
-export CYCLE_TAG="c0027.001"
+export CYCLE_TAG="c0027"
 export TS_DDSCONFIG_PACKAGE="v0.10.1"
 export OPENSPLICE_VERSION="V6.10.4"
 

--- a/docker/versions.sh
+++ b/docker/versions.sh
@@ -2,8 +2,8 @@
 #
 
 # t&s base container version
-export CYCLE_TAG="c0026"
-export TS_DDSCONFIG_PACKAGE="v0.10.0"
+export CYCLE_TAG="c0027.001"
+export TS_DDSCONFIG_PACKAGE="v0.10.1"
 export OPENSPLICE_VERSION="V6.10.4"
 
 export LSST_DDS_RESPONSIVENESS_TIMEOUT="15s"


### PR DESCRIPTION
Change version numbers
Remove old setups and versions of packages that overrode the stack versions.